### PR TITLE
Fix missing logo in footer by setting $govuk-assets-path sass variable

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,3 +1,4 @@
+$govuk-assets-path: "~govuk-frontend/govuk/assets/";
 @import "node_modules/govuk-frontend/govuk/all";
 
 body {


### PR DESCRIPTION
Originally raised as https://github.com/surevine/govuk-react-jsx/issues/61 - I have fixed the missing logo from your footer by setting the $govuk-asset-path sass variable to point to the appropriate location in such that the appropriate webpack loaders pick it up.