### PR TITLE
Localise numbers on Y axis on the charts

### DIFF
--- a/src/components/BarChart/BarChart.js
+++ b/src/components/BarChart/BarChart.js
@@ -44,6 +44,12 @@ const BarChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =>
                 gridLines: {
                   drawBorder: false,
                 },
+                ticks: {
+                  beginAtZero: true,
+                  userCallback: function(value, index, values) {
+                    return value.toLocaleString();
+                  },
+                },
               }],
             },
             tooltips: {

--- a/src/components/LineChart/LineChart.js
+++ b/src/components/LineChart/LineChart.js
@@ -54,6 +54,12 @@ const LineChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =
                 gridLines: {
                   drawBorder: false,
                 },
+                ticks: {
+                  beginAtZero: true,
+                  userCallback: function(value, index, values) {
+                    return value.toLocaleString();
+                  },
+                },
               }],
             },
             tooltips: {


### PR DESCRIPTION
All numbers on the page are localised, with the exception of numbers on the Y axis on the charts. Where I am, this means that numbers on the page are formatted with commas for thousands "93,873", but on the Y axis of the chart it has "80000". This commit localises the number of the Y axis, so it now shows "80,000".

Before:
<img width="524" alt="image" src="https://user-images.githubusercontent.com/19988/79305568-8f036480-7eeb-11ea-95f1-8067bc594373.png">

After:
<img width="520" alt="image" src="https://user-images.githubusercontent.com/19988/79305604-9b87bd00-7eeb-11ea-96cd-8754ddd2429f.png">
