### PR TITLE
Add min and max zoom to the map, improve default centroid/zoom

### DIFF
--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -69,8 +69,10 @@ const Map: ComponentType<Props> = ({
   useEffect(() => {
     const initializeMap = () => {
       const map = L.map('map', {
-        center: [55, -4],
-        zoom: 4.5, 
+        center: [55.7, -3.7],
+        zoom: 5.4,
+        minZoom: 5.4,
+        maxZoom: 11,
         layers: [
           L.mapboxGL({
             attribution: "<a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">&copy; OpenStreetMap contributors</a>",

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -72,7 +72,7 @@ const Map: ComponentType<Props> = ({
         center: [55.7, -3.7],
         zoom: 5.4,
         minZoom: 5.4,
-        maxZoom: 11,
+        maxZoom: 12,
         layers: [
           L.mapboxGL({
             attribution: "<a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">&copy; OpenStreetMap contributors</a>",


### PR DESCRIPTION
Currently it's easy to scroll the page and accidentally scroll
the map to a zoom level that shows no useful information. Fix this.

Also, the default map view shows a lot of sea. Amend this to
show all of the UK, but less sea.