### PR TITLE
Make table headers sticky.

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -90,3 +90,17 @@ button {
     padding: 0;
   }
 }
+
+/* Sticky table headers */
+thead th {
+    position: sticky;
+    top: 0;
+    background-color: #fff;
+}
+/* No gap at top of list to prevent list bleedthrough above thead */
+.js-enabled .govuk-tabs__panel {
+    padding-top: 0;
+}
+.js-enabled .govuk-tabs__panel .govuk-table__header {
+    padding-top: 20px;
+}


### PR DESCRIPTION
Apologies if this is not the correct place to put this.
Someone suggested that the table headers should be 'sticky', so remain in place as you scroll the longer lists (LAs, the tables at the bottom), and I think this should hopefully do it. The extra bits besides the main (which is all that's needed for the bottom tables) are because of the default padding in the tabs panel meaning you can see things above the sticky heading, so I moved the padding from the panel to the header.