### PR TITLE
Add chart of number of tests performed per day.

### DIFF
--- a/src/components/ChartTable/ChartTable.js
+++ b/src/components/ChartTable/ChartTable.js
@@ -13,7 +13,8 @@ const titles: TitleOrDescriptionValues = {
     totalCases: 'Total number of lab-confirmed cases in England by specimen date',
     dailyCases: 'Daily number of lab-confirmed cases in England by specimen date',
     totalDeaths: 'Total number of COVID-19 associated UK deaths in hospital by date reported',
-    dailyDeaths: 'Daily number of COVID-19 associated UK deaths in hospital by date reported'
+    dailyDeaths: 'Daily number of COVID-19 associated UK deaths in hospital by date reported',
+    dailyTests: 'Daily number of tests in UK by date performed'
 
 }; // titles
 
@@ -23,7 +24,8 @@ const TableDescriptions: TitleOrDescriptionValues = {
     totalCases: 'Total confirmed cases and change from previously reported figures. New cases are attributed to the day the specimen was taken.',
     dailyCases: 'Confirmed cases and change from previously reported figures. New cases are attributed to the day the specimen was taken.',
     totalDeaths: null,
-    dailyDeaths: null
+    dailyDeaths: null,
+    dailyTests: null
 
 }; // titles
 
@@ -32,7 +34,8 @@ const ChartDescriptions: TitleOrDescriptionValues = {
     totalCases: null,
     dailyCases: 'Total confirmed cases showing those previously reported and newly added cases separately. New cases are attributed to the day the specimen was taken.',
     totalDeaths: null,
-    dailyDeaths: null
+    dailyDeaths: null,
+    dailyTests: null
 
 }; // titles
 

--- a/src/components/ChartTable/Charts.js
+++ b/src/components/ChartTable/Charts.js
@@ -47,6 +47,12 @@ export const Charts = ({data, titles, descriptions}: ChartsProps): ReactNode => 
                 header={ titles.dailyDeaths }
                 tooltipText="deaths"
             />
+
+            <BarChart
+                data={ overview?.K02000001?.dailyTests ?? [] }
+                header={ titles.dailyTests }
+                tooltipText="tests"
+            />
         </Fragment>
 
 }; // charts

--- a/src/components/ChartTable/Tables.js
+++ b/src/components/ChartTable/Tables.js
@@ -199,6 +199,12 @@ export const Tables = ({ data, titles, descriptions }: TablesProps): ReactNode =
             header={ titles.dailyDeaths }
             valueName="Daily deaths"
         />
+
+        <AltChartTable
+            data={ overview?.K02000001?.dailyTests ?? [] }
+            header={ titles.dailyTests }
+            valueName="Daily tests"
+        />
     </Fragment>
 
 }; // tables

--- a/src/hooks/useLoadData.js
+++ b/src/hooks/useLoadData.js
@@ -17,7 +17,33 @@ const useLoadData = () => {
         getData();
     }, []);
 
-    return data;
+  // TEMPORARY: Remove once testing data is added to the official endpoint.
+  // data.disclaimer should also be updated in the endpoint with details
+  // of the data source.
+  if (data) {
+    data["overview"]["K02000001"]["dailyTests"] = [
+      { "date": "2020-04-22", "value": 23560 },
+      { "date": "2020-04-21", "value": 22814 },
+      { "date": "2020-04-20", "value": 18206 },
+      { "date": "2020-04-19", "value": 19316 },
+      { "date": "2020-04-18", "value": 21626 },
+      { "date": "2020-04-17", "value": 21389 },
+      { "date": "2020-04-16", "value": 21328 },
+      { "date": "2020-04-15", "value": 18665 },
+      { "date": "2020-04-14", "value": 15994 },
+      { "date": "2020-04-13", "value": 14982 },
+      { "date": "2020-04-12", "value": 14506 },
+      { "date": "2020-04-11", "value": 18000 },
+      { "date": "2020-04-10", "value": 18091 },
+      { "date": "2020-04-09", "value": 19116 },
+      { "date": "2020-04-08", "value": 16095 },
+      { "date": "2020-04-07", "value": 14682 },
+      { "date": "2020-04-06", "value": 14006 },
+      { "date": "2020-04-05", "value": 13069 }
+    ];
+  }
+
+  return data;
 };
 
 export default useLoadData;

--- a/src/hooks/useLoadData.js
+++ b/src/hooks/useLoadData.js
@@ -22,6 +22,9 @@ const useLoadData = () => {
   // of the data source.
   if (data) {
     data["overview"]["K02000001"]["dailyTests"] = [
+      { "date": "2020-04-25", "value": 29058 },
+      { "date": "2020-04-24", "value": 28760 },
+      { "date": "2020-04-23", "value": 28532 },
       { "date": "2020-04-22", "value": 23560 },
       { "date": "2020-04-21", "value": 22814 },
       { "date": "2020-04-20", "value": 18206 },

--- a/src/pages/About/About.js
+++ b/src/pages/About/About.js
@@ -191,11 +191,19 @@ const About: ComponentType<Props> = ({ }: Props) => {
             <Styles.SectionHeader className={"govuk-heading-m"}>
                 Deaths over time
             </Styles.SectionHeader>
-            <p className={"govuk-body"}>
+            <p className={'govuk-body govuk-body govuk-!-margin-bottom-8'}>
                 Deaths are shown in charts and tables according to the day they were reported, not the day they
                 occurred. They can be downloaded as a csv file.
             </p>
-            <hr className={"govuk-section-break govuk-section-break--l"} />
+
+            <Styles.SectionHeader className={"govuk-heading-m"}>
+                Tests over time
+            </Styles.SectionHeader>
+            <p className={"govuk-body"}>
+                Test data is reported by DHSC. Tests are shown in charts and tables according to the day on which they were
+                carried out. Data earlier than 21 April excludes tests in Northern Ireland.
+            </p>
+            <hr className={"govuk-section-break govuk-section-break--l"}/>
 
             <p className={"govuk-body-s"}>
                 Updated 2:35pm 26 April 2020

--- a/types/Data.js
+++ b/types/Data.js
@@ -18,6 +18,7 @@ declare export type OverviewData = {
     dailyConfirmedCases: ChartData,
     dailyTotalDeaths: ChartData,
     dailyDeaths: ChartData,
+    dailyTests: ChartData
 };
 
 


### PR DESCRIPTION
(**Note:** Data stubbed manually as not yet present in official endpoint. The endpoint will need to be updated before this PR can be merged.)

**Rationale for PR**

It would be useful for testing information to be added to the official dashboard. This PR adds a chart of the number of tests performed per day.

<img width="590" alt="Screenshot 2020-04-24 at 09 34 50" src="https://user-images.githubusercontent.com/78156/80192292-dd60e380-860e-11ea-97c2-5bffb8d2e259.png">

**Further note on data**

The data I have used is taken from DHSC's [daily Twitter reports](https://twitter.com/search?q=%22tests%20on%22%20(from%3ADHSCgovuk)&src=typed_query&f=live), which are also subject to small [post hoc amendments](https://www.gov.uk/guidance/coronavirus-covid-19-information-for-the-public#number-of-cases-and-deaths), so the numbers in the stub may not match final numbers precisely. Hopefully DHSC can easily make a time series available. 

The DHSC numbers before 21 April exclude Northern Ireland. This is noted on the About page.