### PR TITLE
Sticky table heads

### DIFF
--- a/src/components/RegionTable/RegionTable.js
+++ b/src/components/RegionTable/RegionTable.js
@@ -61,7 +61,7 @@ const RegionTable: ComponentType<Props> = ({
     const item = document.getElementById(itemId);
     if (container && item && item.offsetParent) {
       // $FlowFixMe
-      container.scrollTop = item.offsetParent.offsetTop - 10;
+      container.scrollTop = item.offsetParent.offsetTop - 50;
     }
   }, [country, region, utla]);
 
@@ -145,7 +145,7 @@ const RegionTable: ComponentType<Props> = ({
             panel: {
               children: [
                 <Table key='local-authorities'
-                       head={[{ children: [<abbr title={ "Upper tier local authority" }>UTLA</abbr>] }, { children: ['Total cases'], format: 'numeric' }]}
+                       head={[{ children: [<abbr key={ `abbr_0` } title={ "Upper tier local authority" }>UTLA</abbr>] }, { children: ['Total cases'], format: 'numeric' }]}
                   rows={utlaKeys.sort(sortFunc(utlaData)).map(r => [
                     { children: [<LinkOrText id={`table-link-${r}`} key={`table-link-${r}`} onClick={handleOnUtlaClick(r)} onKeyPress={handleOnUtlaKeyDown} active={utla === r}>{utlaData[r].name.value}</LinkOrText>] },
                     { children: [numeral(utlaData[r].totalCases.value).format('0,0')], format: 'numeric' },

--- a/src/index.scss
+++ b/src/index.scss
@@ -102,3 +102,18 @@ button {
     padding: 0;
   }
 }
+
+// Sticky table headers
+thead.govuk-table__head th{
+  position: sticky;
+  top: 0;
+  background-color: #fff;
+}
+
+// No gap at top of list to prevent list bleedthrough above thead
+.js-enabled .govuk-tabs__panel {
+    padding-top: 0;
+}
+.js-enabled .govuk-tabs__panel  .govuk-table__header {
+    padding-top: 20px;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4551,6 +4551,11 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
+floatthead@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/floatthead/-/floatthead-2.1.4.tgz#3c6678ac6e28e55a5d2f3fc261d33b59210c9827"
+  integrity sha512-ddQOHZGah8zZebLGTxICF1W8T5BiiVQio2ur9lqSIGEUJSa7vb7CI8sVEsXQ+KfXScBQWwI9ViAMFKq9YYlS+w==
+
 flow-bin@^0.120.1:
   version "0.120.1"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.120.1.tgz#ab051d6df71829b70a26a2c90bb81f9d43797cae"
@@ -11359,11 +11364,6 @@ xmlchars@^2.1.1:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/xmlchars/-/xmlchars-2.2.0.tgz#060fe1bcb7f9c76fe2a17db86a9bc3ab894210cb"
   integrity sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
-
-xmltojson@^1.3.5:
-  version "1.3.5"
-  resolved "https://registry.yarnpkg.com/xmltojson/-/xmltojson-1.3.5.tgz#a57d3e0110404b83f62deefa0fcfc465772332e9"
-  integrity sha1-pX0+ARBAS4P2Le76D8/EZXcjMuk=
 
 xtend@^4.0.0, xtend@~4.0.1:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4551,11 +4551,6 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
-floatthead@^2.1.4:
-  version "2.1.4"
-  resolved "https://registry.yarnpkg.com/floatthead/-/floatthead-2.1.4.tgz#3c6678ac6e28e55a5d2f3fc261d33b59210c9827"
-  integrity sha512-ddQOHZGah8zZebLGTxICF1W8T5BiiVQio2ur9lqSIGEUJSa7vb7CI8sVEsXQ+KfXScBQWwI9ViAMFKq9YYlS+w==
-
 flow-bin@^0.120.1:
   version "0.120.1"
   resolved "https://registry.yarnpkg.com/flow-bin/-/flow-bin-0.120.1.tgz#ab051d6df71829b70a26a2c90bb81f9d43797cae"


### PR DESCRIPTION
Based primarily on PR #42 - the solution proposed by @dracos (with thanks).

- Makes `govuk_table` sticky and alters the offset value to accommodate click events.
- Also adds `<abbr>` to UTLA for a tooltip display.
- Removes unused packages.