### PR TITLE
Fail more gracefully on WebGL error

### DIFF
--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -50,9 +50,27 @@ const regionCoordinates = {
 };
 
 function glAvailable () {
-  var canvas = document.createElement("canvas");
-  var gl = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
-  return (gl && gl instanceof WebGLRenderingContext);
+  if (!window.WebGLRenderingContext) {
+    // WebGL is not supported
+    return false;
+  }
+  // WebGL is supported
+  var canvas = document.createElement("canvas"),
+    names = ["webgl2", "webgl", "experimental-webgl", "moz-webgl", "webkit-3d"],
+    context = false;
+
+  for (var i = 0; i < names.length; i++) {
+    try {
+      context = canvas.getContext(names[i]);
+      if (context && typeof context.getParameter == "function") {
+        // WebGL is enabled
+        return true;
+      }
+    }
+    catch (e) {}
+  }
+  // WebGL is disabled
+  return false;
 }
 
 const Map: ComponentType<Props> = ({

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -50,27 +50,28 @@ const regionCoordinates = {
 };
 
 function glAvailable () {
-  if (!window.WebGLRenderingContext) {
-    // WebGL is not supported
-    return false;
-  }
+  if (!window.WebGLRenderingContext) 
+    return false; // WebGL is not supported
+  
   // WebGL is supported
-  var canvas = document.createElement("canvas"),
-    names = ["webgl2", "webgl", "experimental-webgl", "moz-webgl", "webkit-3d"],
+  const 
+    canvas = document.createElement("canvas"),
+    drivers = ["webgl2", "webgl", "experimental-webgl", "moz-webgl", "webkit-3d"],
     context = false;
 
-  for (var i = 0; i < names.length; i++) {
+  for ( const driverName of drivers ) {
     try {
-      context = canvas.getContext(names[i]);
-      if (context && typeof context.getParameter == "function") {
-        // WebGL is enabled
-        return true;
-      }
-    }
-    catch (e) {}
+      
+      context = canvas.getContext(driverName);
+      
+      if (context && typeof context.getParameter == "function") 
+        return true;  // WebGL is enabled
+      
+    } catch (e) {}
   }
-  // WebGL is disabled
-  return false;
+  
+  return false;  // WebGL is disabled
+  
 }
 
 const Map: ComponentType<Props> = ({

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -49,6 +49,12 @@ const regionCoordinates = {
   E12000008: [51.45097, -0.99311], 
 };
 
+function glAvailable () {
+  var canvas = document.createElement("canvas");
+  var gl = canvas.getContext("webgl") || canvas.getContext("experimental-webgl");
+  return (gl && gl instanceof WebGLRenderingContext);
+}
+
 const Map: ComponentType<Props> = ({
   country,
   setCountry,
@@ -88,7 +94,7 @@ const Map: ComponentType<Props> = ({
       setMap(map);
     };
 
-    if (!map) {
+    if (!map && glAvailable()) {
       initializeMap();
     }
   }, []);


### PR DESCRIPTION
Fixes #16. Currently the entire page turns blank when trying to load the map if WebGL is not supported. This PR adds a check (`glAvailable()`) for WebGL before trying to load the map. If the check fails, it doesn’t try to load it, and the map appears as an empty box instead.