### PR TITLE
Fix page width

### DIFF
--- a/src/index.scss
+++ b/src/index.scss
@@ -1,4 +1,5 @@
 $govuk-assets-path: "~govuk-frontend/govuk/assets/";
+$govuk-page-width: 1045px;
 @import "node_modules/govuk-frontend/govuk/all";
 
 body {
@@ -11,13 +12,6 @@ body {
 
   & .govuk-header {
     border-color: #1d70b8;
-    padding-left: 15px;
-
-    & .govuk-header__container {
-      margin-right: auto;
-      margin-left: auto;
-      max-width: 1045px;
-    }
   }
 
   & .gem-c-cookie-banner {


### PR DESCRIPTION
Override the page width by setting `$govuk-page-width`, and remove the current `max-width` overrides targetting govuk-header.

Setting the page width in this way will apply it consistently across the entire page, including the cookie banner and footer.

Closes #89 

## Before

![page-width-before](https://user-images.githubusercontent.com/121939/80534270-e0edc500-8996-11ea-8dd5-971239774d61.png)

## After

![page-width-after](https://user-images.githubusercontent.com/121939/80534291-e77c3c80-8996-11ea-8c86-184a8d43dca7.png)
