### PR TITLE
Use `$govuk-font-family` across the service

### DIFF
--- a/src/components/BarChart/BarChart.js
+++ b/src/components/BarChart/BarChart.js
@@ -85,7 +85,7 @@ const BarChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =>
 
                   let innerHtml = '<thead>';
                   titleLines.forEach(function (title) {
-                    innerHtml += '<tr><th style="text-align: left;">'
+                    innerHtml += '<tr><th class="govuk-body govuk-!-font-weight-bold govuk-!-margin-0" style="text-align: left; color: #fff; font-size: 12px;">'
                       + new Intl.DateTimeFormat('en-GB', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date(title))
                       + '</th></tr>';
                   });
@@ -93,12 +93,9 @@ const BarChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =>
 
                   bodyLines.forEach(function (body, i) {
                     const val = parseInt(body).toLocaleString();
-                    const colors = tooltipModel.labelColors[i];
-                    let style = 'background:' + colors.backgroundColor;
-                    style += '; border-color:' + colors.borderColor;
-                    style += '; border-width: 2px';
-                    const span = '<span style="' + style + '"></span>';
-                    innerHtml += '<tr><td>' + span + val + ' ' + [tooltipText] + '</td></tr>';
+                    const style = `border-width: 2px; color: #fff; font-size: 12px;`;
+                    const span = '<span class="govuk-body govuk-!-margin-0" style="' + style + '">' + val +  ' ' + [tooltipText] + '</span>';
+                    innerHtml += '<tr><td>' + span  + '</td></tr>';
                   });
                   innerHtml += '</tbody>';
 

--- a/src/components/BigNumber/BigNumber.js
+++ b/src/components/BigNumber/BigNumber.js
@@ -12,7 +12,7 @@ const BigNumber: ComponentType<Props> = ({ caption, number, description, asteris
     <Styles.Container>
       <Styles.Caption className="govuk-heading-m">{caption}</Styles.Caption>
       <Styles.Number className="govuk-heading-l">{numeral(number).format('0,0')}{asterisk ? '*' : ''}</Styles.Number>
-      <Styles.Caption className="govuk-!-font-size-16">{description}</Styles.Caption>
+      <Styles.Caption className="govuk-body govuk-!-font-size-16 govuk-!-margin-bottom-1">{description}</Styles.Caption>
     </Styles.Container>
   );
 };

--- a/src/components/BigNumber/BigNumber.styles.js
+++ b/src/components/BigNumber/BigNumber.styles.js
@@ -47,7 +47,5 @@ export const Triangle: ComponentType<*> = (() => {
 })();
 
 export const Subtext: ComponentType<*> = (() => {
-  return styled.span`
-    margin-bottom: 0;
-  `;
+  return styled.span``;
 })();

--- a/src/components/CategoricalBarChart/CategoricalBarChart.js
+++ b/src/components/CategoricalBarChart/CategoricalBarChart.js
@@ -116,7 +116,7 @@ const getBarChartOptions = (tooltipText) => {
                         bodyLines = tooltipModel.body.map(getBody);
                     let innerHtml = '<thead>';
                     titleLines.forEach(function (title) {
-                        innerHtml += `<tr><th style="text-align: left;">${title}</th></tr>`;
+                        innerHtml += `<tr><th class="govuk-body govuk-!-font-weight-bold govuk-!-margin-0" style="text-align: left; color: #fff; font-size: 12px;">${title}</th></tr>`;
                     });
                     innerHtml += '</thead><tbody>';
 
@@ -126,10 +126,9 @@ const getBarChartOptions = (tooltipText) => {
                             number = numeral(/\d+/.exec(val)[0]).format('0,0'),
                             text = /[^\d]+/.exec(val)[0].trim(),
                             contentText = `${text} ${number}`,
-                            colors = tooltipModel.labelColors[i],
-                            style = `background: ${colors.backgroundColor} !important; border-color: ${colors.borderColor}; border-width: 2px;`;
+                            style = `border-width: 2px; color: #fff; font-size: 12px;`;
 
-                        innerHtml += `<tr><td><span style=${style}/>${contentText} ${[tooltipText]}</td></tr>`;
+                        innerHtml += `<tr><td><span class="govuk-body govuk-!-margin-0" style="${style}"/>${contentText} ${[tooltipText]}</td></tr>`;
                     });
                     innerHtml += '</tbody>';
 

--- a/src/components/LineChart/LineChart.js
+++ b/src/components/LineChart/LineChart.js
@@ -95,7 +95,7 @@ const LineChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =
 
                   let innerHtml = '<thead>';
                   titleLines.forEach(function (title) {
-                    innerHtml += '<tr><th style="text-align: left;">'
+                    innerHtml += '<tr><th class="govuk-body govuk-!-font-weight-bold govuk-!-margin-0" style="text-align: left; color: #fff; font-size: 12px;">'
                       + new Intl.DateTimeFormat('en-GB', { year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date(title))
                       + '</th></tr>';
                   });
@@ -103,12 +103,9 @@ const LineChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =
 
                   bodyLines.forEach(function (body, i) {
                     const val = parseInt(body).toLocaleString();
-                    const colors = tooltipModel.labelColors[i];
-                    let style = 'background:' + colors.backgroundColor;
-                    style += '; border-color:' + colors.borderColor;
-                    style += '; border-width: 2px';
-                    const span = '<span style="' + style + '"></span>';
-                    innerHtml += '<tr><td>' + span + val + ' ' + [tooltipText] + '</td></tr>';
+                    const style = `border-width: 2px; color: #fff; font-size: 12px;`;
+                    const span = '<span class="govuk-body govuk-!-margin-0" style="' + style + '">' + val +  ' ' + [tooltipText] + '</span>';
+                    innerHtml += '<tr><td>' + span  + '</td></tr>';
                   });
                   innerHtml += '</tbody>';
 

--- a/src/components/PageTitle/PageTitle.js
+++ b/src/components/PageTitle/PageTitle.js
@@ -17,7 +17,7 @@ const PageTitle: ComponentType<Props> = ({ caption, title, subtitle, backUrl }: 
         </BackLink>
       )}
       <Styles.Title className="govuk-heading-xl">{title}</Styles.Title>
-      <Styles.Subtitle>{subtitle}</Styles.Subtitle>
+      <Styles.Subtitle className="govuk-body govuk-!-margin-bottom-0">{subtitle}</Styles.Subtitle>
     </Styles.Container>
   );
 };

--- a/src/components/PageTitle/PageTitle.styles.js
+++ b/src/components/PageTitle/PageTitle.styles.js
@@ -45,7 +45,5 @@ export const Title: ComponentType<*> = (() => {
 })();
 
 export const Subtitle: ComponentType<*> = (() => {
-  return styled.span`
-    font-size: 1.19rem;
-  `;
+  return styled.span``;
 })();

--- a/src/components/StackedBarChart/StackedBarChart.js
+++ b/src/components/StackedBarChart/StackedBarChart.js
@@ -116,7 +116,7 @@ const getBarChartOptions = (tooltipText) => {
                         bodyLines = tooltipModel.body.map(getBody);
                     let innerHtml = '<thead>';
                     titleLines.forEach(function (title) {
-                        innerHtml += '<tr><th style="text-align: left;">'
+                        innerHtml += '<tr><th class="govuk-body govuk-!-font-weight-bold govuk-!-margin-0" style="text-align: left; color: #fff; font-size: 12px;">'
                             + new Intl.DateTimeFormat('en-GB', {
                                 year: 'numeric',
                                 month: '2-digit',
@@ -132,10 +132,9 @@ const getBarChartOptions = (tooltipText) => {
                             number = numeral(/\d+/.exec(val)[0]).format('0,0'),
                             text = /[^\d]+/.exec(val)[0].trim(),
                             contentText = `${text} ${number}`,
-                            colors = tooltipModel.labelColors[i],
-                            style = `background: ${colors.backgroundColor} !important; border-color: ${colors.borderColor}; border-width: 2px;`;
+                            style = `border-width: 2px; color: #fff; font-size: 12px;`;
 
-                        innerHtml += `<tr><td><span style=${style}/>${contentText} ${[tooltipText]}</td></tr>`;
+                        innerHtml += `<tr><td><span class="govuk-body govuk-!-margin-0" style="${style}"/>${contentText} ${[tooltipText]}</td></tr>`;
                     });
                     innerHtml += '</tbody>';
 

--- a/src/index.scss
+++ b/src/index.scss
@@ -1,10 +1,10 @@
 $govuk-assets-path: "~govuk-frontend/govuk/assets/";
 $govuk-page-width: 1045px;
+$govuk-font-family: "GDS Transport", Arial, sans-serif;
 @import "node_modules/govuk-frontend/govuk/all";
 
 body {
   margin: 0;
-  font-family: "GDS Transport", Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-ononesx-font-smoothing: grayscale;
   background-color: #fff;


### PR DESCRIPTION
This moves the font stack off the `body` element, and uses the `$govuk-font-family` variable everywhere instead.

This identified some knock-on bugs where elements hadn't had the `govuk-` classes applied to them, so they ended up un-styled. The follow-on commits address those small bugs so that the service appears to render the same as before.

Fixes PublicHealthEngland/coronavirus-dashboard#90
