### PR TITLE
Fixes disordered charts when toggling to tables & back

### DIFF
--- a/src/components/BarChart/BarChart.js
+++ b/src/components/BarChart/BarChart.js
@@ -42,27 +42,20 @@ const BarChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =>
             scales: {
               xAxes: [{
                 offset: true,
+                type: 'time',
                 gridLines: {
                   display: false,
+                },
+                time: {
+                    displayFormats: {
+                        quarter: 'MMM YYYY'
+                    },
                 },
                 ticks: {
                   fontSize: 14,
                   fontColor: '#1A2B2B',
-                  autoSkip: false,
-                  userCallback: function (value, index, values) {
-                    const lastValue = dataSorted[index];
-                    const label = moment(lastValue.date).format('MMM DD');
-                    let valuesLength = values.length - 1;
-                    let period = Math.round(valuesLength / 10);
-
-                    if (index % period === 0 && index <= valuesLength - (period / 2)) {
-                      return label;
-                    }
-
-                    if (index === valuesLength) {
-                      return label;
-                    }
-                  }
+                  autoSkip: true,
+                  maxTicksLimit: 15
                 },
               }],
               yAxes: [{

--- a/src/components/ChartTable/ChartTable.js
+++ b/src/components/ChartTable/ChartTable.js
@@ -1,4 +1,4 @@
-import React, { Component, Fragment } from "react";
+import React, { Component, Fragment, ReactNode } from "react";
 
 import ViewAs from 'components/ViewAs';
 

--- a/src/components/ChartTable/Charts.js
+++ b/src/components/ChartTable/Charts.js
@@ -21,6 +21,16 @@ const ageSexSort = (a, b) => {
 }; // ageSexSort
 
 
+const dateSortFunc = (a, b) => {
+
+    const
+        dateA = new Date(a.date),
+        dateB = new Date(b.date);
+
+    return dateA < dateB ? 1 : dateA > dateB || 0;
+
+}; // sortFunc
+
 
 /**
  * Produces the charts.
@@ -49,15 +59,16 @@ export const Charts = ({data, titles, descriptions}: ChartsProps): ReactNode => 
                 tooltip={ '' }
             />
 
-            <LineChart data={ countries?.E92000001?.dailyTotalConfirmedCases ?? [] }
-                       header={ titles.totalCases }
-                       tooltipText="cases"
+            <LineChart
+                data={ (countries?.E92000001?.dailyTotalConfirmedCases ?? []).sort(dateSortFunc) }
+                header={ titles.totalCases }
+                tooltipText="cases"
             />
 
             <StackedBarChart
                 data={ {
-                    previous: countries?.E92000001?.previouslyReportedDailyCasesAdjusted ?? [],
-                    change: countries?.E92000001?.changeInDailyCases ?? [],
+                    previous: (countries?.E92000001?.previouslyReportedDailyCasesAdjusted ?? []).sort(dateSortFunc),
+                    change: (countries?.E92000001?.changeInDailyCases ?? []).sort(dateSortFunc),
                 } }
                 header={ titles.dailyCases }
                 tooltipText="cases"
@@ -65,13 +76,13 @@ export const Charts = ({data, titles, descriptions}: ChartsProps): ReactNode => 
             />
 
             <LineChart
-                data={ overview?.K02000001?.dailyTotalDeaths ?? [] }
+                data={ (overview?.K02000001?.dailyTotalDeaths ?? []).sort(dateSortFunc) }
                 header={ titles.totalDeaths }
                 tooltipText="deaths"
             />
 
             <BarChart
-                data={ overview?.K02000001?.dailyDeaths ?? [] }
+                data={ (overview?.K02000001?.dailyDeaths ?? []).sort(dateSortFunc) }
                 header={ titles.dailyDeaths }
                 tooltipText="deaths"
             />

--- a/src/components/LineChart/LineChart.js
+++ b/src/components/LineChart/LineChart.js
@@ -8,6 +8,17 @@ import * as moment from 'moment';
 import type { Props } from './LineChart.types';
 import * as Styles from './LineChart.styles';
 
+const dateSortFunc = (a, b) => {
+
+    const
+        dateA = new Date(a.date),
+        dateB = new Date(b.date);
+
+    return dateA < dateB ? 1 : dateA > dateB || 0;
+
+}; // sortFunc
+
+
 const LineChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) => {
 
   return (
@@ -37,27 +48,16 @@ const LineChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =
             maintainAspectRatio: false,
             scales: {
               xAxes: [{
+                offset: true,
+                type: 'time',
                 gridLines: {
-                  display: false,
+                  display: true,
                 },
                 ticks: {
                   fontSize: 14,
                   fontColor: '#1A2B2B',
-                  autoSkip: false,
-                  userCallback: function (value, index, values) {
-                    const lastValue = data[index];
-                    const label = moment(lastValue.date).format('MMM DD');
-                    let valuesLength = values.length - 1;
-                    let period = Math.round(valuesLength / 10);
-
-                    if (index % period === 0 && index <= valuesLength - (period / 2)) {
-                      return label;
-                    }
-
-                    if (index === valuesLength) {
-                      return label;
-                    }
-                  }
+                  autoSkip: true,
+                  maxTicksLimit: 15
                 },
               }],
               yAxes: [{

--- a/src/components/StackedBarChart/StackedBarChart.js
+++ b/src/components/StackedBarChart/StackedBarChart.js
@@ -11,20 +11,35 @@ import * as Styles from './StackedBarChart.styles';
 import numeral from 'numeral';
 
 
+const sortFunc = (a, b) => {
+
+    const
+        dateA = new Date(a.date),
+        dateB = new Date(b.date);
+
+    if (dateA < dateB) return 1;
+
+    return dateA > dateB ? -1 : 0
+
+};
+
+
 const getBarChartData = ({ previous, change }) => {
 
+    const previousSorted = previous.sort(sortFunc)
+
     return {
-        labels: previous.map(d => d.date),
+        labels: previousSorted.map(d => d.date),
         datasets: [
             {
                 label: "Previously reported",
                 backgroundColor: '#367E93',
-                data: previous.map(d => d.value)
+                data: previousSorted.map(d => d.value)
             },
             {
                 label: "Newly reported",
                 backgroundColor: '#0a495a',
-                data: change.map(d => d.value > 0 ? d.value : 0)
+                data: change.sort(sortFunc).map(d => d.value > 0 ? d.value : 0)
             }
         ]
     }
@@ -43,6 +58,12 @@ const getBarChartOptions = (tooltipText) => {
         scales: {
             xAxes: [{
                 offset: true,
+                type: 'time',
+                time: {
+                    displayFormats: {
+                        quarter: 'MMM YYYY'
+                    },
+                },
                 gridLines: {
                     display: false,
                 },
@@ -50,20 +71,8 @@ const getBarChartOptions = (tooltipText) => {
                 ticks: {
                     fontSize: 14,
                     fontColor: '#1A2B2B',
-                    autoSkip: false,
-                    userCallback: function (value, index, values) {
-                        const label = moment(value).format('MMM DD');
-                        let valuesLength = values.length - 1;
-                        let period = Math.round(valuesLength / 10);
-
-                        if (index % period === 0 && index <= valuesLength - (period / 2)) {
-                            return label;
-                        }
-
-                        if (index === valuesLength) {
-                            return label;
-                        }
-                    }
+                    maxTicksLimit: 15,
+                    autoSkip: true,
                 },
             }],
             yAxes: [{


### PR DESCRIPTION
Turns out we cannot add manual labels (show the last one) without screwing it up in graph that has date for its x-axis.

Added gridlines in line charts to make it the position of labels clearer to users.

Also limits the number of labels on the x-axis, which should (hopefully) eliminate the need to reduce the font size.

Fixes #131, #132, and hopefully #134. 