### PR TITLE
Improve line graph display on mobile

### DIFF
--- a/src/components/BarChart/BarChart.js
+++ b/src/components/BarChart/BarChart.js
@@ -59,7 +59,6 @@ const BarChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =>
                   fontSize: mobileView ? 11 : 14,
                   fontColor: '#1A2B2B',
                   autoSkip: false,
-                  minTicksLimit: 8,
                   maxTicksLimit: 15
                 },
               }],

--- a/src/components/BarChart/BarChart.js
+++ b/src/components/BarChart/BarChart.js
@@ -25,7 +25,8 @@ const BarChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =>
 
   const
       dataSorted = data.sort(sortFunc),
-      mobileView = useResponsiveLayout(500)  === "mobile";
+      mobileView = useResponsiveLayout(500)  === "mobile",
+      labelFontSize = mobileView ? 11 : 14;
 
   return (
     <Styles.Container>
@@ -56,7 +57,7 @@ const BarChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =>
                 },
                 ticks: {
                   minRotation: 45,
-                  fontSize: mobileView ? 11 : 14,
+                  fontSize: labelFontSize,
                   fontColor: '#1A2B2B',
                   autoSkip: false,
                   maxTicksLimit: 15
@@ -67,7 +68,7 @@ const BarChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =>
                   drawBorder: false,
                 },
                 ticks: {
-                  fontSize: 14,
+                  fontSize: labelFontSize,
                   fontColor: '#1A2B2B',
                   beginAtZero: true,
                   userCallback: function (value, index, values) {

--- a/src/components/CategoricalBarChart/CategoricalBarChart.js
+++ b/src/components/CategoricalBarChart/CategoricalBarChart.js
@@ -72,7 +72,6 @@ const getBarChartOptions = (tooltipText, mobileView: boolean) => {
                     fontSize: mobileView ? 11 : 14,
                     fontColor: '#1A2B2B',
                     autoSkip: false,
-                    minTicksLimit: 8,
                     maxTicksLimit: 15,
                 }
             }],

--- a/src/components/CategoricalBarChart/CategoricalBarChart.js
+++ b/src/components/CategoricalBarChart/CategoricalBarChart.js
@@ -52,6 +52,8 @@ const getBarChartData = ({ data, categoryLabels, colors, columnLabelGetter }: Ca
 
 
 const getBarChartOptions = (tooltipText, mobileView: boolean) => {
+    
+    const labelFontSize = mobileView ? 11 : 14;
 
     return {
         barValueSpacing: 20,
@@ -69,7 +71,7 @@ const getBarChartOptions = (tooltipText, mobileView: boolean) => {
                 stacked: false,
                 ticks: {
                     minRotation: 45,
-                    fontSize: mobileView ? 11 : 14,
+                    fontSize: labelFontSize,
                     fontColor: '#1A2B2B',
                     autoSkip: false,
                     maxTicksLimit: 15,

--- a/src/components/LineChart/LineChart.js
+++ b/src/components/LineChart/LineChart.js
@@ -24,7 +24,10 @@ const dateSortFunc = (a, b) => {
 
 const LineChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) => {
 
-  const mobileView = useResponsiveLayout(500)  === "mobile"
+  const 
+      mobileView = useResponsiveLayout(500)  === "mobile"
+      labelFontSize = mobileView ? 11 : 14;
+        
 
   return (
     <Styles.Container>
@@ -59,7 +62,7 @@ const LineChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =
                 },
                 ticks: {
                   minRotation: 45,
-                  fontSize: mobileView ? 11 : 14,
+                  fontSize: labelFontSize,
                   fontColor: '#1A2B2B',
                   autoSkip: true,
                   maxTicksLimit: 15
@@ -70,7 +73,7 @@ const LineChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =
                   drawBorder: false,
                 },
                 ticks: {
-                  fontSize: 14,
+                  fontSize: labelFontSize,
                   fontColor: '#1A2B2B',
                   beginAtZero: true,
                   userCallback: function (value, index, values) {

--- a/src/components/LineChart/LineChart.js
+++ b/src/components/LineChart/LineChart.js
@@ -25,7 +25,7 @@ const dateSortFunc = (a, b) => {
 const LineChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) => {
 
   const 
-      mobileView = useResponsiveLayout(500)  === "mobile"
+      mobileView = useResponsiveLayout(500)  === "mobile",
       labelFontSize = mobileView ? 11 : 14;
         
 

--- a/src/components/LineChart/LineChart.js
+++ b/src/components/LineChart/LineChart.js
@@ -63,7 +63,6 @@ const LineChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =
                   fontSize: mobileView ? 11 : 14,
                   fontColor: '#1A2B2B',
                   autoSkip: true,
-                  minTicksLimit: 8,
                   maxTicksLimit: 15
                 },
               }],

--- a/src/components/LineChart/LineChart.js
+++ b/src/components/LineChart/LineChart.js
@@ -53,7 +53,6 @@ const LineChart: ComponentType<Props> = ({ header, tooltipText, data }: Props) =
             maintainAspectRatio: false,
             scales: {
               xAxes: [{
-                offset: true,
                 type: 'time',
                 gridLines: {
                   display: true,

--- a/src/components/StackedBarChart/StackedBarChart.js
+++ b/src/components/StackedBarChart/StackedBarChart.js
@@ -73,7 +73,6 @@ const getBarChartOptions = (tooltipText, mobileView) => {
                     minRotation: 45,
                     fontSize: mobileView ? 11 : 14,
                     fontColor: '#1A2B2B',
-                    minTicksLimit: 8,
                     maxTicksLimit: 15,
                     autoSkip: false,
                 },

--- a/src/components/StackedBarChart/StackedBarChart.js
+++ b/src/components/StackedBarChart/StackedBarChart.js
@@ -49,6 +49,8 @@ const getBarChartData = ({ previous, change }) => {
 
 
 const getBarChartOptions = (tooltipText, mobileView) => {
+    
+    const labelFontSize = mobileView ? 11 : 14;
 
     return {
         maintainAspectRatio: false,
@@ -71,7 +73,7 @@ const getBarChartOptions = (tooltipText, mobileView) => {
                 stacked: true,
                 ticks: {
                     minRotation: 45,
-                    fontSize: mobileView ? 11 : 14,
+                    fontSize: labelFontSize,
                     fontColor: '#1A2B2B',
                     maxTicksLimit: 15,
                     autoSkip: false,
@@ -83,7 +85,7 @@ const getBarChartOptions = (tooltipText, mobileView) => {
                 },
                 stacked: true,
                 ticks: {
-                    fontSize: 14,
+                    fontSize: labelFontSize,
                     fontColor: '#1A2B2B',
                     beginAtZero: true,
                     userCallback: function (value, index, values) {


### PR DESCRIPTION
The line graph has a large gap either side at small width:

![image](https://user-images.githubusercontent.com/154364/80861000-981e6080-8c63-11ea-9cca-0d0f2f3d12c2.png)

Switching offset off for the line graph makes it look like this instead:

![image](https://user-images.githubusercontent.com/154364/80861283-82119f80-8c65-11ea-9c91-ca908531d6a7.png)

Hope that's useful. Also, `minTicksLimit` was recently added, but this variable does not appear to be used by any code.