### PR TITLE
Add aria-label to the map canvas

### DIFF
--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -95,18 +95,23 @@ const Map: ComponentType<Props> = ({
     // Initialise map
     useEffect(() => {
         const initializeMap = () => {
+            const mapbox = L.mapboxGL({
+                attribution: '<a href="http://www.openstreetmap.org/about/" target="_blank">&copy; OpenStreetMap contributors</a>',
+                style: 'https://c19tile.azureedge.net/style.json'
+            });
             const map = L.map('map', {
                 center: [55.7, -3.7],
                 zoom: 5.4,
                 minZoom: 5.4,
                 maxZoom: 12,
                 layers: [
-                    L.mapboxGL({
-                        attribution: "<a href=\"http://www.openstreetmap.org/about/\" target=\"_blank\">&copy; OpenStreetMap contributors</a>",
-                        style: 'https://c19tile.azureedge.net/style.json'
-                    })
+                    mapbox
                 ]
             });
+            const canvas = mapbox.getCanvas();
+            if (canvas) {
+                canvas.setAttribute('aria-label', 'Heat map showing number of coronavirus cases by region in the UK');
+            }
 
             map.zoomControl.setPosition('bottomright');
 

--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -110,7 +110,7 @@ const Map: ComponentType<Props> = ({
             });
             const canvas = mapbox.getCanvas();
             if (canvas) {
-                canvas.setAttribute('aria-label', 'Heat map showing number of coronavirus cases by region in the UK');
+                canvas.setAttribute('aria-label', 'Map showing number of COVID-19 cases by nation, region, or local authority in the UK');
             }
 
             map.zoomControl.setPosition('bottomright');


### PR DESCRIPTION
It looks like the default aria-label ("Map") is coming directly from mapbox-gl:

https://github.com/mapbox/mapbox-gl-js/blame/d0f42e4274a0972f27c1e7f1546aea58491d2a4c/src/ui/map.js#L2285

There doesn't seem to be a nice way to configure this as a user of
mapbox-gl, so the easiest thing to do is just fish the canvas out of the
DOM and reset the attribute.

Note that this needs to be done after `L.map()` is called, because the
`mapbox` doesn't get its DOM until its used in the Leaflet map.

Fixes #80