### PR TITLE
Set role="main" on main content of each page

### DIFF
--- a/src/pages/About/About.js
+++ b/src/pages/About/About.js
@@ -59,7 +59,7 @@ export default class About extends Component<AboutProps, {}> {
 
     render(): React$Node {
 
-        return <Styles.Container className={"govuk-width-container about"}>
+        return <Styles.Container className={"govuk-width-container about"} role="main">
             { this.display() }
         </Styles.Container>
 

--- a/src/pages/Accessibility/Accessibility.js
+++ b/src/pages/Accessibility/Accessibility.js
@@ -59,7 +59,7 @@ export default class Accessibility extends Component<AccessibilityProps, {}> {
 
     render(): React$Node {
 
-        return <Styles.Container className={"govuk-width-container accessibility"}>
+        return <Styles.Container className={"govuk-width-container accessibility"} role="main">
             { this.display() }
         </Styles.Container>
 

--- a/src/pages/Archive/Archive.js
+++ b/src/pages/Archive/Archive.js
@@ -194,7 +194,7 @@ export default class Archive extends Component<ArchiveProps, {}> {
 
     render(): React.ReactNode {
 
-        return <Container className={"govuk-width-container"}>
+        return <Container className={"govuk-width-container"} role="main">
             <SectionHeader className={ "govuk-heading-l" }>
                 Archive
             </SectionHeader>

--- a/src/pages/Archive/Archive.style.js
+++ b/src/pages/Archive/Archive.style.js
@@ -3,7 +3,7 @@ import addIECss from "addIECss";
 
 export const Container: ComponentType<*> = (() =>
 
-      styled.div`
+      styled.main`
         grid-column: 1/-1;
         display: flex;
         flex-direction: column;

--- a/src/pages/Cookies/Cookies.js
+++ b/src/pages/Cookies/Cookies.js
@@ -73,7 +73,7 @@ const Cookies: ComponentType<Props> = ({ }: Props) => {
     };
 
     return (
-        <Styles.Container className={"govuk-width-container"}>
+        <Styles.Container className={"govuk-width-container"} role="main">
 
             {getCookiesUpdatedText()}
 

--- a/src/pages/MobileRegionTable/MobileRegionTable.js
+++ b/src/pages/MobileRegionTable/MobileRegionTable.js
@@ -31,7 +31,7 @@ const MobileRegionTable: ComponentType<Props> = ({}: Props) => {
   }
 
   return (
-    <Styles.Container className="govuk-width-container">
+    <Styles.Container className="govuk-width-container" role="main">
       <PageTitle
         caption="Regional view"
         title="Coronavirus (COVID-19) in the UK"

--- a/src/pages/MobileRegionTable/MobileRegionTable.styles.js
+++ b/src/pages/MobileRegionTable/MobileRegionTable.styles.js
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 import type { ComponentType } from 'react';
 
 export const Container: ComponentType<*> = (() => {
-  return styled.div`
+  return styled.main`
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 30px;

--- a/src/pages/Regional/Regional.js
+++ b/src/pages/Regional/Regional.js
@@ -73,7 +73,7 @@ const Regional: ComponentType<Props> = ({}: Props) => {
     const layout = useResponsiveLayout(768);
 
     if ( !data ) {
-        return <Styles.Container className="govuk-width-container">
+        return <Styles.Container className="govuk-width-container" role="main">
             <Styles.P className={ "govuk-body govuk-!-font-size-24" }>
                 The website is loading. Please wait&hellip;
             </Styles.P>
@@ -81,7 +81,7 @@ const Regional: ComponentType<Props> = ({}: Props) => {
     }
 
     return (
-        <Styles.Container className="govuk-width-container">
+        <Styles.Container className="govuk-width-container" role="main">
 
             <Announcement firstDisplayDate={ { year: 2020, month: 4, day: 27 } }
                           lastDisplayDate={ { year: 2020, month: 5, day: 1 } }>

--- a/src/pages/Regional/Regional.styles.js
+++ b/src/pages/Regional/Regional.styles.js
@@ -6,7 +6,7 @@ import type { ComponentType } from 'react';
 import addIECss from 'addIECss';
 
 export const Container: ComponentType<*> = (() => {
-  return styled.div`
+  return styled.main`
     display: grid;
     grid-template-columns: repeat(6, 1fr);
     grid-column-gap: 30px;


### PR DESCRIPTION
Fixes #79

Additionally, there were some pages where we were using the `<main>`
element (from HTML 5), and some where we were using `<div>`. I've used
`<main role="main">` everywhere now to make things consistent (the `role` is
still useful for older browsers / assistive tech).