### PR TITLE
Error boundary

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     ]
   },
   "devDependencies": {
+    "dotenv": "^8.2.0",
     "flow-bin": "^0.120.1"
   }
 }

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,11 @@
 /* eslint-disable react-hooks/exhaustive-deps */
+
 import React,  { Fragment } from 'react';
 import { Switch, Route, Redirect } from 'react-router';
 import { Header, Footer } from 'govuk-react-jsx';
+
+// handle environment vars
+import dotenv from 'dotenv';
 
 import Regional from 'pages/Regional';
 import MobileRegionTable from 'pages/MobileRegionTable';
@@ -13,6 +17,8 @@ import Navigation from 'components/Navigation';
 import CookieBanner from 'components/CookieBanner';
 import BackToTop from 'components/BackToTop';
 
+// get environment vars
+dotenv.config();
 
 const FooterContents = () => {
 

--- a/src/App.js
+++ b/src/App.js
@@ -16,6 +16,7 @@ import Cookies from 'pages/Cookies';
 import Navigation from 'components/Navigation';
 import CookieBanner from 'components/CookieBanner';
 import BackToTop from 'components/BackToTop';
+import ErrorBoundary from "components/ErrorBoundary";
 
 // get environment vars
 dotenv.config();
@@ -78,32 +79,35 @@ const App = () => {
             />
             <Navigation/>
 
-            {/* We only want back-to-top links on the main & about pages. */}
-            <Switch>
-                {/* These back-to-top links are the 'overlay' style that stays
-                    on screen as we scroll. */}
-                <Route path="/about" exact render={ () => <BackToTop mode={ "overlay" }/> } />
-                <Route path="/accessibility" exact render={ () => <BackToTop mode={ "overlay" }/> } />
-                <Route path="/" exact render={ () => <BackToTop mode={ "overlay" }/> } />
-            </Switch>
+            <ErrorBoundary>
 
-            <Switch>
-                <Route path="/region" component={ MobileRegionTable }/>
-                <Route path="/about" component={ About }/>
-                <Route path="/accessibility" component={ Accessibility }/>
-                <Route path="/cookies" component={ Cookies }/>
-                <Route path="/archive" component={ Archive }/>
-                <Route path="/" component={ Regional }/>
-                <Redirect to="/"/>
-            </Switch>
+                {/* We only want back-to-top links on the main & about pages. */}
+                <Switch>
+                    {/* These back-to-top links are the 'overlay' style that stays
+                        on screen as we scroll. */}
+                    <Route path="/about" exact render={ () => <BackToTop mode={ "overlay" }/> } />
+                    <Route path="/accessibility" exact render={ () => <BackToTop mode={ "overlay" }/> } />
+                    <Route path="/" exact render={ () => <BackToTop mode={ "overlay" }/> } />
+                </Switch>
 
-            {/* We only want back-to-top links on the main & about pages. */}
-            <Switch>
-                {/* These back-to-top links are the 'inline' style that sits
-                    statically between the end of the content and the footer. */}
-                <Route path="/about" exact render={ props => <BackToTop {...props} mode="inline"/> } />
-                <Route path="/" exact render={ props => <BackToTop {...props} mode="inline"/>  } />
-            </Switch>
+                <Switch>
+                    <Route path="/region" component={ MobileRegionTable }/>
+                    <Route path="/about" component={ About }/>
+                    <Route path="/accessibility" component={ Accessibility }/>
+                    <Route path="/cookies" component={ Cookies }/>
+                    <Route path="/archive" component={ Archive }/>
+                    <Route path="/" component={ Regional }/>
+                    <Redirect to="/"/>
+                </Switch>
+
+                {/* We only want back-to-top links on the main & about pages. */}
+                <Switch>
+                    {/* These back-to-top links are the 'inline' style that sits
+                        statically between the end of the content and the footer. */}
+                    <Route path="/about" exact render={ props => <BackToTop {...props} mode="inline"/> } />
+                    <Route path="/" exact render={ props => <BackToTop {...props} mode="inline"/>  } />
+                </Switch>
+            </ErrorBoundary>
 
             <Switch>
                 <Route path="/region" component={ F }/>

--- a/src/components/ErrorBoundary/ErrorBoundary.js
+++ b/src/components/ErrorBoundary/ErrorBoundary.js
@@ -30,9 +30,19 @@ export default class ErrorBoundary extends React.Component<Props, State> {
             return <Styles.Container className="govuk-width-container" role="main">
                 <PageTitle title={"Something went wrong"} />
 
-                <p className={"govuk-body"}>
+                <p className="govuk-body">
                     There was an error. Please try again later.
                 </p>
+                <p className="govuk-body">
+                    If the problem persists, please contact us via <a href="mailto:coronavirus-tracker@phe.gov.uk" className="govuk-link">coronavirus-tracker@phe.gov.uk</a> and include:
+                </p>
+                <ul className="govuk-list govuk-list--bullet">
+                    <li>Details of what you were trying to do that caused the problem</li>
+                    <li>Your operating system (such as Windows, Mac OS, Android, iOS) and its version if possible</li>
+                    <li>Your platform (such as mobile, table, computer)</li>
+                    <li>Your browser (such as Chrome, Edge, Firefox, Internet Explorer)</li>
+                    <li>The technical details quoted below</li>
+                </ul>
                 <details className="govuk-details" data-module="govuk-details">
                     <summary className="govuk-details__summary">
                         <span className="govuk-details__summary-text">

--- a/src/components/ErrorBoundary/ErrorBoundary.js
+++ b/src/components/ErrorBoundary/ErrorBoundary.js
@@ -39,7 +39,7 @@ export default class ErrorBoundary extends React.Component<Props, State> {
                 <ul className="govuk-list govuk-list--bullet">
                     <li>Details of what you were trying to do that caused the problem</li>
                     <li>Your operating system (such as Windows, Mac OS, Android, iOS) and its version if possible</li>
-                    <li>Your platform (such as mobile, table, computer)</li>
+                    <li>Your platform (such as mobile, tablet, computer)</li>
                     <li>Your browser (such as Chrome, Edge, Firefox, Internet Explorer)</li>
                     <li>The technical details quoted below</li>
                 </ul>

--- a/src/components/ErrorBoundary/ErrorBoundary.js
+++ b/src/components/ErrorBoundary/ErrorBoundary.js
@@ -34,14 +34,14 @@ export default class ErrorBoundary extends React.Component<Props, State> {
                     There was an error. Please try again later.
                 </p>
                 <p className="govuk-body">
-                    If the problem persists, please contact us via <a href="mailto:coronavirus-tracker@phe.gov.uk" className="govuk-link">coronavirus-tracker@phe.gov.uk</a> and include:
+                    If the problem persists, contact us via <a href="mailto:coronavirus-tracker@phe.gov.uk" className="govuk-link">coronavirus-tracker@phe.gov.uk</a> and include:
                 </p>
                 <ul className="govuk-list govuk-list--bullet">
-                    <li>Details of what you were trying to do that caused the problem</li>
-                    <li>Your operating system (such as Windows, Mac OS, Android, iOS) and its version if possible</li>
-                    <li>Your platform (such as mobile, tablet, computer)</li>
-                    <li>Your browser (such as Chrome, Edge, Firefox, Internet Explorer)</li>
-                    <li>The technical details quoted below</li>
+                    <li>details of what you were trying to do that caused the problem</li>
+                    <li>your operating system (such as Windows, Mac OS, Android, iOS) and its version if possible</li>
+                    <li>your platform (such as mobile, tablet, computer)</li>
+                    <li>your browser (such as Chrome, Edge, Firefox, Internet Explorer)</li>
+                    <li>the technical details quoted below</li>
                 </ul>
                 <details className="govuk-details" data-module="govuk-details">
                     <summary className="govuk-details__summary">

--- a/src/components/ErrorBoundary/ErrorBoundary.js
+++ b/src/components/ErrorBoundary/ErrorBoundary.js
@@ -2,32 +2,55 @@
 
 import React from 'react';
 
-type Props = {
-  children: any,
-};
+import PageTitle from 'components/PageTitle';
+import type { Props } from './ErrorBoundary.types';
+import * as Styles from './ErrorBoundary.styles';
 
-type State = {
-  hasError: boolean
-};
 
 export default class ErrorBoundary extends React.Component<Props, State> {
-  props: Props;
-  state: State = {
-    hasError: false,
+    props: Props;
+    state: State = {
+        error: null,
+        errorInfo: null
   };
 
-  componentDidCatch() {
-    this.setState({
-      hasError: true,
-    });
+  componentDidCatch(error, errorInfo) {
+        // Catch errors in any components below and re-render with error message
+        this.setState({
+            error: error,
+            errorInfo: errorInfo
+        })
+        // You can also log error messages to an error reporting service here
   }
 
   render() {
-    const { hasError } = this.state;
+        if (this.state.errorInfo) {
 
-    if (hasError) {
-      return null;
+            // Error path
+            return <Styles.Container className="govuk-width-container" role="main">
+                <PageTitle title={"Something went wrong"} />
+
+                <p className={"govuk-body"}>
+                    There was an error. Please try again later.
+                </p>
+                <details className="govuk-details" data-module="govuk-details">
+                    <summary className="govuk-details__summary">
+                        <span className="govuk-details__summary-text">
+                            Technical details
+                        </span>
+                    </summary>
+                    <Styles.DetailsBody className="govuk-details__text">
+                        {this.state.error && this.state.error.toString()}
+                        <br/>
+                        {this.state.errorInfo.componentStack}
+                    </Styles.DetailsBody>
+                </details>
+
+            </Styles.Container>
+
+        }
+        // Normally, just render children
+        return this.props.children;
     }
-    return this.props.children;
-  }
+
 }

--- a/src/components/ErrorBoundary/ErrorBoundary.styles.js
+++ b/src/components/ErrorBoundary/ErrorBoundary.styles.js
@@ -1,0 +1,19 @@
+// @flow
+
+import styled from 'styled-components';
+import type { ComponentType } from 'react';
+
+export const Container: ComponentType<*> = (() => {
+    return styled.main `
+        display: flex;
+        flex-direction: column;
+        margin-top: 45px;
+        margin-bottom: 120px;
+    `;
+})();
+
+export const DetailsBody: ComponentType<*> = (() => {
+    return styled.div `
+        white-space: pre-wrap;
+    `;
+})();

--- a/src/components/ErrorBoundary/ErrorBoundary.types.js
+++ b/src/components/ErrorBoundary/ErrorBoundary.types.js
@@ -1,0 +1,3 @@
+// @flow
+
+export type Props = {||};

--- a/src/components/MapTable/Map.js
+++ b/src/components/MapTable/Map.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import ReactDomServer from 'react-dom/server'
 
 import axios from "axios";
@@ -7,7 +7,6 @@ import L from "leaflet";
 import { max } from "d3-array";
 import { scaleLinear, scaleSqrt } from "d3-scale";
 
-import ErrorBoundary from "components/ErrorBoundary";
 import URLs from "common/urls";
 
 import 'leaflet/dist/leaflet.css';
@@ -290,10 +289,11 @@ export class Map extends Component<MapProps, {}> {
 
         }
 
-        return <ErrorBoundary>
+        return <Fragment>
             { this.display() }
             <Styles.Map id={ "map" }>{ children }</Styles.Map>
-        </ErrorBoundary>
+        </Fragment>
+
 
     } // render
 


### PR DESCRIPTION
Implements an error boundary for pages/components and displays an error page with helpful content. Header, Navigation and Footer are not included in this boundary.

This PR also adds a 'dotenv' package as a development dependency. This is to support building the app locally.