### PR TITLE
Changed scroll on table to "auto"

### DIFF
--- a/src/components/GovUk/Table.styles.js
+++ b/src/components/GovUk/Table.styles.js
@@ -58,7 +58,7 @@ export const TableContainer: ComponentType<*> =
     styled
         .div`
             max-height: 350px;
-            overflow: scroll;
+            overflow: auto;
             
             &>table {
                 font-size: 1.1rem;


### PR DESCRIPTION
on Windows forced scroll on elements without actually overflowing content looks ugly

I've noticed issue on https://coronavirus.data.gov.uk/deaths

before the change:
![image](https://user-images.githubusercontent.com/733336/95130955-3d7aba80-0755-11eb-8822-5465a704d1ea.png)

after the change:
![image](https://user-images.githubusercontent.com/733336/95131105-6d29c280-0755-11eb-8332-4d6c339f7db6.png)
