### PR TITLE
Fix flow config

### DIFF
--- a/.flowconfig
+++ b/.flowconfig
@@ -13,7 +13,6 @@ module.file_ext=.js
 module.file_ext=.json
 module.system.node.resolve_dirname=node_modules
 module.system.node.resolve_dirname=src
-suppress_comment= \\(.\\|\n\\)*\\$FlowFixMe
 esproposal.optional_chaining=enable
 
 [libs]


### PR DESCRIPTION
This PR removes 'suppress_comment' option from the .flowconfig file.
This option was removed from flow in version 0.126
as per https://flow.org/en/docs/config/options/#toc-suppress-comment-regex
and it's presence was causing the command `yarn lint` to fail.