### PR TITLE
Revert "Bump trim-newlines from 3.0.0 to 3.0.1"

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -16059,9 +16059,9 @@ triangulate-polyline@^1.0.0:
     cdt2d "^1.0.0"
 
 trim-newlines@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
-  integrity sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.0.tgz#79726304a6a898aa8373427298d54c2ee8b1cb30"
+  integrity sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
 
 trough@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Reverts publichealthengland/coronavirus-dashboard#418