### PR TITLE
resolves #448 - design tweaks

### DIFF
--- a/src/components/ChangeLogComponent/ChangeLogComponent.styles.js
+++ b/src/components/ChangeLogComponent/ChangeLogComponent.styles.js
@@ -40,8 +40,9 @@ export const ChangeLogSpan: ComponentType<*> =
         bgColor,
         className: `${className} govuk-!-font-size-14`
     }))`
-        float: right;
+        float: left;
         padding: 2px 5px;
+        margin-right: 5px;
         font-weight: 600;
         text-transform: uppercase;
         color: ${calcColour};

--- a/src/components/ChangeLogComponent/ChangeLogItem.js
+++ b/src/components/ChangeLogComponent/ChangeLogItem.js
@@ -124,11 +124,11 @@ const ChangeLogHeading: ComponentType = ({ data }) => {
                 <span className={ "govuk-visually-hidden" }>Date of change: </span>
                 { moment(data.date).format("D MMMM") }
             </time>
-            <ChangeLogSpan color={ colours[data.type]?.text ?? "#000000" }
-                           bgColor={ colours[data.type]?.background ?? "inherit" }>
-                <span className={ "govuk-visually-hidden" }>Type of log: </span>{ data.type }
-            </ChangeLogSpan>
         </small>
+        <ChangeLogSpan color={ colours[data.type]?.text ?? "#000000" }
+                       bgColor={ colours[data.type]?.background ?? "inherit" }>
+            <span className={ "govuk-visually-hidden" }>Type of log: </span>{ data.type }
+        </ChangeLogSpan>
         {
             data?.relativeUrl
                 ? data.relativeUrl.indexOf("details") > -1

--- a/src/components/ChangeLogComponent/FilterComponents/Filters.js
+++ b/src/components/ChangeLogComponent/FilterComponents/Filters.js
@@ -40,8 +40,6 @@ const ChangeLogFilters: ComponentType<*> = ({ children }) => {
             !isOpen
                 ? null
                 : <>
-                    <hr className={ "govuk-section-break govuk-section-break--visible" }
-                        style={ { borderColor: "#1d70b8", borderWidth: 2 } }/>
                     <p className={ "govuk-visually-hidden" }>Use these options to filter the logs.</p>
                     <TextSearch/>
                     <div style={ { display: "grid", gridGap: "1rem" } }>


### PR DESCRIPTION
resolves #448 - Moves the tag to the left of each heading and removes the blue line from filters
![image](https://user-images.githubusercontent.com/66849242/128346861-5a1059d8-7c1f-49b2-9e83-98c8dee3e682.png)
