### PR TITLE
Map: Display Zero Case Growth in Grey

### DIFF
--- a/src/components/Map/Map.js
+++ b/src/components/Map/Map.js
@@ -28,6 +28,7 @@ import MapMarker from "assets/icon-mapmarker.svg";
 import useTimestamp from "hooks/useTimestamp";
 import usePrevious from "hooks/usePrevious";
 import GreenArrow from "assets/icon-arrow-green.svg";
+import GreyArrow from "assets/arrow.svg";
 import RedArrow from "assets/icon-arrow-red.svg";
 import { scaleColours } from "common/utils";
 import useGenericAPI from "hooks/useGenericAPI";
@@ -127,7 +128,7 @@ const Arrow = ({ direction }) => {
         case "SAME":
         default:
             angle = 90;
-            ArrowImage = GreenArrow;
+            ArrowImage = GreyArrow;
             altText = "The rate has not changed relative to the previous week.";
             break;
     }
@@ -143,6 +144,9 @@ const InfoCard = ({ areaName, date, rollingRate, totalThisWeek, totalChange, tre
 
 
     if ( !setShowInfo ) return null;
+
+    let colourStatus = percentageChange > 0 ? "red" : "green";
+    if ( percentageChange === 0 ) colourStatus = "neutral";
 
     return <MapToolbox>
         <button style={{ position: "absolute", top: 3, right: 8, margin: 0, padding: 0, cursor: "pointer", fontSize: 1.5 + "rem" }}
@@ -162,7 +166,7 @@ const InfoCard = ({ areaName, date, rollingRate, totalThisWeek, totalChange, tre
                         <h3 className={ "govuk-heading-s" }>Total cases</h3>
                         <div className={ "number-row" }>
                             <span className={ "number" }>{ totalThisWeek }</span>
-                            <strong className={ `govuk-tag ${ percentageChange > 0 ? "red" : "green" } number` }>
+                            <strong className={ `govuk-tag ${ colourStatus } number` }>
                                 <Arrow direction={ trend }/>
                                 { numeral(totalChange).format("0,0") }&nbsp;{ `(${ numeral(percentageChange).format("0,0.0") }%)` }
                             </strong>

--- a/src/components/Map/Map.styles.js
+++ b/src/components/Map/Map.styles.js
@@ -253,7 +253,7 @@ export const NumberBox: ComponentType<*> =
             
             &.neutral {
                 color: rgb(56,63,67);
-                background-color: rgb(235,233,231.2);
+                background-color: rgb(235,233,231);
             }
         }
     }

--- a/src/components/Map/Map.styles.js
+++ b/src/components/Map/Map.styles.js
@@ -250,6 +250,11 @@ export const NumberBox: ComponentType<*> =
                 background-color: rgb(199,39,8,.2);
                 background: rgb(199,39,8,.2);
             }
+            
+            &.neutral {
+                color: rgb(56,63,67);
+                background-color: rgb(235,233,231.2);
+            }
         }
     }
     `;


### PR DESCRIPTION
Ensures that the box is grey rather than green when there has not been a change in coronavirus cases.

**Testing instructions:**

1. Go to `/details/interactive-map/cases`
2. Either manually force an area to have zero case growth, or find an area that actually has not had a change in COVID cases (Oxfordshire is currently one) 
3. Verify that the colour is grey (the shade is taken from the homepage) instead of green

| Before                                                                                                                                                                | After                                                                                                                                                                 |
|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| <img width="337" alt="Screenshot 2021-08-30 at 10 08 23" src="https://user-images.githubusercontent.com/43215253/131316479-d8655922-90cb-45a8-b58b-9b3a3476146c.png"> | <img width="336" alt="Screenshot 2021-08-30 at 10 08 28" src="https://user-images.githubusercontent.com/43215253/131316488-48ecfca2-c05a-42dc-b70a-02b96ea55375.png"> |

Fixes #464

@xenatisch apologies - I recognise that you were assigned to the issue, but I couldn't find a branch for this and I assume it wasn't already being worked on because it's a Bank Holiday? Would appreciate if you could review, thanks! :) 