### PR TITLE
fix(506): back button works on whats new page

### DIFF
--- a/src/components/ChangeLogComponent/ChangeLogComponent.js
+++ b/src/components/ChangeLogComponent/ChangeLogComponent.js
@@ -141,7 +141,7 @@ const ChangeLogComponent: ComponentType<*> = ({ colours }: ChangeLogInputProps) 
 
     }, [page, query, date]);
 
-    if ( !data.length && !isLoading ) {
+    if ( data !== undefined && !data.length && !isLoading ) {
         return <PageComponent>
             <p className={ "govuk-!-font-weight-bold" }>
                 There are no logs that match the criteria.
@@ -153,7 +153,7 @@ const ChangeLogComponent: ComponentType<*> = ({ colours }: ChangeLogInputProps) 
         return <PageComponent><Loading/></PageComponent>;
     }
 
-    const processedData = groupBy(data, item => item.date.substring(0, 7));
+    const processedData = groupBy(data ? data : [], item => item.date.substring(0, 7));
     const groups = Object.keys(processedData);
 
     return <PageComponent feedPath={ "change_logs" }>

--- a/src/components/ChangeLogComponent/FilterComponents/CategorySearch.js
+++ b/src/components/ChangeLogComponent/FilterComponents/CategorySearch.js
@@ -27,7 +27,10 @@ export const CategorySearch: ComponentType<*> = ({}) => {
         } else {
             params = params.filter(item => item.key !== "title");
         }
-        history.push({ search: createQuery(params) });
+        // do not push into history stack when not searched
+        if( params !== undefined && params.length !== 0 ) {
+            history.push({ search: createQuery(params) });
+        }
     }, [title]);
 
     if ( !options ) return <Loading/>;

--- a/src/components/ChangeLogComponent/FilterComponents/DateSearch.js
+++ b/src/components/ChangeLogComponent/FilterComponents/DateSearch.js
@@ -27,7 +27,7 @@ export const DateSearch: ComponentType<*> = ({}) => {
                 pathname: `/details/whats-new/${ date }`,
                 search: history.location.search
             })
-        } else {
+        } else if (!!history.location.search) { // do not push into history stack when not searched
             history.push({
                 pathname: `/details/whats-new`,
                 search: history.location.search

--- a/src/components/ChangeLogComponent/FilterComponents/TypeSearch.js
+++ b/src/components/ChangeLogComponent/FilterComponents/TypeSearch.js
@@ -27,7 +27,10 @@ export const TypeSearch: ComponentType<*> = ({}) => {
         } else {
             params = params.filter(item => item.key !== "type");
         }
-        history.push({ search: createQuery(params) });
+        // do not push into history stack when not searched
+        if( params !== undefined && params.length !== 0 ) {
+            history.push({ search: createQuery(params) });
+        }
     }, [type]);
 
     if ( !options ) return <Loading/>;


### PR DESCRIPTION
closes #506 

Notice the issue being because the filter components were loading. They were creating a history stack on the initial load when not needed.

Hope this helps, just wanted to give it try :)