### PR TITLE
add exclusion filters for area name location picker on details pages

### DIFF
--- a/src/components/DashboardHeader/Constants.js
+++ b/src/components/DashboardHeader/Constants.js
@@ -146,5 +146,5 @@ export const MSOAMetricOptions = [
     // { value: "cumPeopleVaccinatedCompleteByVaccinationDate", label: "cumPeopleVaccinatedCompleteByVaccinationDate", deprecated: "2021-10-16" },
 ];
 
-export const ExcludedAreaNames = ["Isles of Scilly", "City of London"
+export const ExcludedAreaNames = ["Isles of Scilly", "City of London", "United Kingdom"
 ];

--- a/src/components/DashboardHeader/Constants.js
+++ b/src/components/DashboardHeader/Constants.js
@@ -145,3 +145,6 @@ export const MSOAMetricOptions = [
     // { value: "cumVaccinationCompleteCoverageByVaccinationDatePercentage", label: "cumVaccinationCompleteCoverageByVaccinationDatePercentage", deprecated: "2021-10-16" },
     // { value: "cumPeopleVaccinatedCompleteByVaccinationDate", label: "cumPeopleVaccinatedCompleteByVaccinationDate", deprecated: "2021-10-16" },
 ];
+
+export const ExcludedAreaNames = ["Isles of Scilly", "City of London"
+];

--- a/src/components/DashboardHeader/LocationPicker.js
+++ b/src/components/DashboardHeader/LocationPicker.js
@@ -201,7 +201,7 @@ const LocationPicker = ({ show, setCurrentLocation, currentLocation }) => {
                                   aria-describedby={ 'aria-name-description' }>
                                 <Select options={ areaNameData.data.filter(item => item.label.toLowerCase() !== "united kingdom" && !ExcludedAreaNames.includes(item.label)) }
                                         styles={ SelectOptions }
-                                        value={ areaNameData.data.filter(item => item.label === currentLocation.areaName ) }
+                                        value={ areaNameData.data.filter(item => item.label === currentLocation.areaName) }
                                         isLoading={ data.length < 1 }
                                         placeholder={ "Select area" }
                                         onChange={ item => setCurrentLocation({

--- a/src/components/DashboardHeader/LocationPicker.js
+++ b/src/components/DashboardHeader/LocationPicker.js
@@ -6,7 +6,7 @@ import { Link } from "react-router-dom";
 
 import { createQuery, getParams, groupBy } from "common/utils";
 import { getOrder } from "./GenericHooks";
-import { PathNames } from "./Constants";
+import { PathNames, ExcludedAreaNames } from "./Constants";
 import Select from "react-select";
 import { LocalisationForm, LocalisationFormInputs } from "./DashboardHeader.styles";
 import useGenericAPI from "../../hooks/useGenericAPI";
@@ -199,9 +199,9 @@ const LocationPicker = ({ show, setCurrentLocation, currentLocation }) => {
                             </span>
                             <div aria-labelledby={ "aria-name-label" }
                                   aria-describedby={ 'aria-name-description' }>
-                                <Select options={ areaNameData.data.filter(item => item.label.toLowerCase() !== "united kingdom") }
+                                <Select options={ areaNameData.data.filter(item => item.label.toLowerCase() !== "united kingdom" && !ExcludedAreaNames.includes(item.label)) }
                                         styles={ SelectOptions }
-                                        value={ areaNameData.data.filter(item => item.label === currentLocation.areaName) }
+                                        value={ areaNameData.data.filter(item => item.label === currentLocation.areaName ) }
                                         isLoading={ data.length < 1 }
                                         placeholder={ "Select area" }
                                         onChange={ item => setCurrentLocation({

--- a/src/components/DashboardHeader/LocationPicker.js
+++ b/src/components/DashboardHeader/LocationPicker.js
@@ -199,7 +199,7 @@ const LocationPicker = ({ show, setCurrentLocation, currentLocation }) => {
                             </span>
                             <div aria-labelledby={ "aria-name-label" }
                                   aria-describedby={ 'aria-name-description' }>
-                                <Select options={ areaNameData.data.filter(item => item.label.toLowerCase() !== "united kingdom" && !ExcludedAreaNames.includes(item.label)) }
+                                <Select options={ areaNameData.data.filter(item => !ExcludedAreaNames.includes(item.label)) }
                                         styles={ SelectOptions }
                                         value={ areaNameData.data.filter(item => item.label === currentLocation.areaName) }
                                         isLoading={ data.length < 1 }


### PR DESCRIPTION
currently filtering out "Isles of Scilly", "City of London", "United Kingdom"
resolves #425 