### PR TITLE
COVP-96 The Zoom and Home buttons on charts are not working - investigate

### DIFF
--- a/src/components/Plotter/BasePlot.js
+++ b/src/components/Plotter/BasePlot.js
@@ -468,6 +468,8 @@ export const BasePlotter: ComponentType<*> = ({ data: payload, layout = {}, xaxi
                         "lasso2d",
                         "zoomIn2d",
                         "zoomOut2d",
+                        "zoom",
+                        "resetScale",
                         ...width === "desktop" ? []: ["zoom"]
                     ],
                     toImageButtonOptions: {


### PR DESCRIPTION
Added _zoom_ and _resetScale_ to _modeBarButtonsToRemove_ property of plotly configuration.