### PR TITLE
Increase max-old-space-size value for postbuild

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "lint": "yarn flow",
     "start": "unset HOST && react-scripts start",
     "build": "unset HOST && export NODE_OPTIONS=--max-old-space-size=8192 && react-scripts build",
-    "postbuild": "node scripts/patchUrls.js",
+    "postbuild": "./scripts/old_space_size.sh && export NODE_OPTIONS=--max-old-space-size=8192 && node scripts/patchUrls.js",
     "ppostbuild": "react-snap",
     "test": "react-scripts test",
     "eject": "react-scripts eject"

--- a/scripts/old_space_size.sh
+++ b/scripts/old_space_size.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+node -e 'console.log(`*** NODE HEAP LIMIT = ${require("v8").getHeapStatistics().heap_size_limit / (1024 * 1024)} Mb`)'


### PR DESCRIPTION
NODE_OPTIONS/max-old-space-size increased to 8192
(also added a script to show actual value before the change)