### PR TITLE
COVP-173 Fix for 'Metrics documentation' page

### DIFF
--- a/src/components/MetricView/MetricView.js
+++ b/src/components/MetricView/MetricView.js
@@ -32,7 +32,7 @@ const Metrics: ComponentType<*> = ({ data, filter }) => {
             <Content>
                 <Link className={ "govuk-link govuk-link--no-underline govuk-link--no-visited-state govuk-!-font-weight-bold" }
                       to={ `/metrics/doc/${metric.metric}` }
-                      dangerouslySetInnerHTML={ markedContent(metric.metric_name, filter) }/>
+                      dangerouslySetInnerHTML={ markedContent(metric.metric_name ?? metric.metric, filter) }/>
                 <HeadingLabels>
                     { metric.deprecated ? <Deprecated>DEPRECATED</Deprecated> : null }
                     <Category>{ metric.category }</Category>


### PR DESCRIPTION
Added the 'Nullish Coalescing Operator' (??) to use **metric** instead of **metric_name** if the latter is null.
That will prevent the page form breaking if the **metric_name** is null (some new metrics that were created automatically by the etl).