### PR TITLE
COVP-173 Fix metrics name search

### DIFF
--- a/src/pages/MetricDocs/Sections/MetricName.js
+++ b/src/pages/MetricDocs/Sections/MetricName.js
@@ -70,7 +70,12 @@ const Metrics: ComponentType<*> = ({ metrics, setUri }) => {
                     userInput
                         ?  (
                             item.metric.toLowerCase().indexOf(userInput.replace(/[^a-z6028\s]/gi, "")) > -1 ||
-                            item.metric_name.toLowerCase().indexOf(userInput.replace(/[^a-z6028\s]/gi, "")) > -1
+                            // metric_name can be null, in that case don't use it in search
+                            (
+                                item.metric_name == null
+                                    ? false
+                                    : item.metric_name.toLowerCase().indexOf(userInput.replace(/[^a-z6028\s]/gi, "")) > -1
+                            )
                         )
                         : true
                 ) &&


### PR DESCRIPTION
This fixes another bit of code affected by **metric_name** being _null_.