### PR TITLE
COVP-173 Fix filtering metrics by category

### DIFF
--- a/src/pages/MetricDocs/Sections/MetricName.js
+++ b/src/pages/MetricDocs/Sections/MetricName.js
@@ -81,7 +81,7 @@ const Metrics: ComponentType<*> = ({ metrics, setUri }) => {
                 ) &&
                 (
                     categories
-                        ? item.category.toLowerCase() === categories.toLowerCase()
+                        ? (item.category != null ? item.category.toLowerCase() === categories.toLowerCase() : false)
                         : true
                 ) &&
                 (


### PR DESCRIPTION
Added checking if metric category is null to prevent app from breaking (page errors).